### PR TITLE
setup: Use docker --format to fix local tags on recent docker versions

### DIFF
--- a/tcb-env-setup.sh
+++ b/tcb-env-setup.sh
@@ -198,8 +198,7 @@ fi
 remote_tags=$(curl -L -s 'https://registry.hub.docker.com/v2/namespaces/torizon/repositories/torizoncore-builder/tags' | sed -n -e 's/\("name"\) *: *\("[^"]\+"\)/\n\1:\2\n/gp' | \
               sed -n -e 's/"name":"\([^"]\+\)"/\1/p')
 # Get list of image tags locally
-# TODO RegEx Fails on MacOS. This one works: sed -En 's/^.*torizoncore-builder[[:space:]]+([0-9]+).*$/\1/p'
-local_tags=$(docker images torizon/torizoncore-builder | sed -n 's/^.*torizoncore-builder\s\+\([0-9]\+\).*$/\1/p')
+local_tags=$(docker images torizon/torizoncore-builder --format '{{.Tag}}')
 
 # Determine the tag with the greatest numerical major revision
 get_latest_tag () {


### PR DESCRIPTION
On recent docker versions (tested with docker 29), the output format of `docker images` was changed, which causes:

	❯ . tcb-env-setup/tcb-env-setup.sh -a local
	WARNING: This output is designed for human readability. For machine-readable output, please use --format.
	Error: no local versions found!

This commit implements what the warning suggests, using `--format` to get stable output and removing the need for a complex and non-portable sed at the same time.

This fixes #5.